### PR TITLE
Fix for bug reported in issue #23

### DIFF
--- a/montanha/templates/detail_legislator.html
+++ b/montanha/templates/detail_legislator.html
@@ -9,7 +9,7 @@
 
     <div class="row">
         <div class="span12">
-            <h1>{{ legislator.name }} ({{ legislator.party }})</h1>
+            <h1>{{ legislator.name }} ({% if legislator.party %}{{ legislator.party }}{% else %}Partido não informado{% endif %})</h1>
         </div>
     </div>
     <div class="row">

--- a/montanha/templates/per_legislator.html
+++ b/montanha/templates/per_legislator.html
@@ -38,7 +38,7 @@
                                     /
                                 {% endif %}
                                 {% if m.party.logo %}<img src="{{ m.party.logo|thumbnail_url:'mini' }}" title="{{ m.party.name }}" alt="{{ m.party.name }}">{% endif %}
-                                {% if m.party.siglum %} {{ m.party.siglum }} {% else %} Partido não informado {% endif %} ({{ m.date_start.year }}{% if m.date_end.year %} - {{ m.date_end.year }} {% endif %})
+                                {% if m.party.siglum %} {{ m.party.siglum }} {% else %} Partido não informado {% endif %} ({{ m.date_start.year }}{% if m.date_end.year %} - {{ m.date_end.year }}{% endif %})
                             {% endfor %}
                         </td>
                         <td>{{ d.expensed|format_currency }}</td>


### PR DESCRIPTION
I put a null / empty check for the property legislator.party in the view. For empty cases is exhibited 'Partido não informado'. I removed too an annoying space before the last parenthesis in the per-legislator page.